### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/branch-sha--no-skip-pr.yaml
+++ b/.github/workflows/branch-sha--no-skip-pr.yaml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Action Updater
-        uses: saadmk11/github-actions-version-updater@use-pydantic
+        uses: saadmk11/github-actions-version-updater@v0.7.3
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
           commit_message: "Custom Commit Message"

--- a/.github/workflows/branch-sha--skip-pr.yaml
+++ b/.github/workflows/branch-sha--skip-pr.yaml
@@ -7,12 +7,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Action Updater
-        uses: saadmk11/github-actions-version-updater@use-pydantic
+        uses: saadmk11/github-actions-version-updater@v0.7.3
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
           commit_message: "Custom Commit Message"

--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Action Updater
-        uses: saadmk11/github-actions-version-updater@use-pydantic
+        uses: saadmk11/github-actions-version-updater@v0.7.3
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 

--- a/.github/workflows/release-commit-sha--no-skip-pr.yaml
+++ b/.github/workflows/release-commit-sha--no-skip-pr.yaml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Action Updater
-        uses: saadmk11/github-actions-version-updater@use-pydantic
+        uses: saadmk11/github-actions-version-updater@v0.7.3
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
           commit_message: "Custom Commit Message"

--- a/.github/workflows/release-commit-sha--skip-pr.yaml
+++ b/.github/workflows/release-commit-sha--skip-pr.yaml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Action Updater
-        uses: saadmk11/github-actions-version-updater@use-pydantic
+        uses: saadmk11/github-actions-version-updater@v0.7.3
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
           commit_message: "Custom Commit Message"

--- a/.github/workflows/release-tag--no-skip-pr.yaml
+++ b/.github/workflows/release-tag--no-skip-pr.yaml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.3.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@use-pydantic
+        uses: saadmk11/github-actions-version-updater@v0.7.3
         with:
           committer_username: 'test'
           committer_email: 'test@test.com'

--- a/.github/workflows/release-tag--skip-pr.yaml
+++ b/.github/workflows/release-tag--skip-pr.yaml
@@ -7,12 +7,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 
       - name: Run GitHub Action Updater
-        uses: saadmk11/github-actions-version-updater@use-pydantic
+        uses: saadmk11/github-actions-version-updater@v0.7.3
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
           commit_message: "Custom Commit Message"

--- a/.github/workflows/test-regular.yaml
+++ b/.github/workflows/test-regular.yaml
@@ -23,9 +23,9 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.3.0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4.5.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -44,15 +44,15 @@ jobs:
       run: |
         coverage run --parallel -m pytest -x
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3.1.1
       with:
         fail_ci_if_error: true
   lint_python:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.3.0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4.5.0
       with:
         python-version: 3.7
     - name: Install dependencies
@@ -66,9 +66,9 @@ jobs:
   lint_js:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.3.0
     - name: Set up NodeJS
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3.6.0
     - name: Install dependencies
       run: |
         npm ci
@@ -78,9 +78,9 @@ jobs:
   sandbox:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.3.0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4.5.0
       with:
         python-version: 3.8
     - name: Build sandbox
@@ -90,9 +90,9 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.3.0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4.5.0
       with:
         python-version: 3.8
     - name: Build docs

--- a/.github/workflows/test-sub-dir.yaml
+++ b/.github/workflows/test-sub-dir.yaml
@@ -10,14 +10,14 @@ jobs:
       image: bilelmoussaoui/flatpak-github-actions:gnome-40
       options: --privileged
     steps:
-    - uses: actions/checkout@v2
-    - uses: flatpak/flatpak-github-actions/flatpak-builder@v1
+    - uses: actions/checkout@v3.3.0
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v5
       name: "Build"
       with:
         bundle: palette.flatpak
         manifest-path: org.gnome.zbrown.Palette.yml
         cache-key: flatpak-builder-${{ github.sha }}
-    - uses: flatpak/flatpak-github-actions/flat-manager@v1
+    - uses: flatpak/flatpak-github-actions/flat-manager@v5
       name: "Deploy"
       with:
         repository: elementary


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.7.3](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.7.3)** on 2023-01-08T15:45:06Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v3.6.0](https://github.com/actions/setup-node/releases/tag/v3.6.0)** on 2023-01-05T14:09:37Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.3.0](https://github.com/actions/checkout/releases/tag/v3.3.0)** on 2023-01-05T13:21:21Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.5.0](https://github.com/actions/setup-python/releases/tag/v4.5.0)** on 2023-01-12T11:29:27Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v3.1.1](https://github.com/codecov/codecov-action/releases/tag/v3.1.1)** on 2022-09-19T15:25:54Z
* **[flatpak/flatpak-github-actions](https://github.com/flatpak/flatpak-github-actions)** published a new release **[v5](https://github.com/flatpak/flatpak-github-actions/releases/tag/v5)** on 2022-12-24T14:47:02Z
